### PR TITLE
Add support for setting CD-Audio volume via SB mixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For now, this fork provides additional support:
 * Additional sound card support
   * SIS 7012
   * CMI 8338 / 8738 (untested)
+* CD-Audio (via 4-pin audio header) unmute/mixer support
 
 ## Supported sound cards
 
@@ -132,3 +133,25 @@ processes to speed up building:
 
 After the build is done, you'll find the build result in a folder called
 `output`, i.e. `output/sbemu-x.exe`.
+
+## Feature usage
+
+### CD Audio
+
+CD audio support in DOS requires two parts:
+
+1. Audio control (play/pause/seek/...) via `MSCDEX` (or `SHSUCDX`)
+2. Volume control via the mixer
+
+For part one, you need to have a CD-ROM drive with analog audio out
+and an MSCDEX-compatible CD-ROM driver set up.
+
+Part two (volume control) is taken care of by SBEMU-X on startup.
+
+To adjust the volume of CD-Audio (by default it's 100% volume),
+you can use any Sound Blaster-compatible program, such as "SBMIX",
+as SBEMU-X does emulate and forward CD-Audio mixer settings.
+
+Don't forget that to actually hear anything, you need to connect
+an analog audio cable from your CD-ROM drive to the 4-pin CD-IN
+header on your soundcard (or motherboard for onboard sound).

--- a/main.c
+++ b/main.c
@@ -776,25 +776,39 @@ static void MAIN_Interrupt()
     int32_t vol;
     int32_t voicevol;
     int32_t midivol;
+    int32_t cdvol; // 0-100 (percentage)
+    static int32_t last_cdvol = -1;
     if(MAIN_Options[OPT_TYPE].value == 1 || MAIN_Options[OPT_TYPE].value == 3) //SB2.0 and before
     {
         vol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_MASTERVOL) >> 1)*256/7;
         voicevol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_VOICEVOL) >> 1)*256/3;
         midivol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_MIDIVOL) >> 1)*256/7;
+        cdvol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_CDVOL) >> 1)*100/7;
     }
     else if(MAIN_Options[OPT_TYPE].value == 6) //SB16
     {
+        // TODO: This only uses the left channel volume as volume for both left and right
         vol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_MASTERSTEREO)>>4)*256/15; //4:4
         voicevol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_VOICESTEREO)>>4)*256/15; //4:4
         midivol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_MIDISTEREO)>>4)*256/15; //4:4
+        cdvol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_CDSTEREO)>>4)*100/15; //4:4
         //_LOG("vol: %d, voicevol: %d, midivol: %d\n", vol, voicevol, midivol);
     }
     else //SBPro
     {
+        // TODO: This only uses the left channel volume as volume for both left and right
         vol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_MASTERSTEREO)>>5)*256/7; //3:1:3:1 stereo usually the same for both channel for games?;
         voicevol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_VOICESTEREO)>>5)*256/7; //3:1:3:1
         midivol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_MIDISTEREO)>>5)*256/7;
+        cdvol = (SBEMU_GetMixerReg(SBEMU_MIXERREG_CDSTEREO)>>5)*100/7;
         //_LOG("vol: %d, voicevol: %d, midivol: %d\n", vol, voicevol, midivol);
+    }
+
+    if (cdvol != last_cdvol) {
+        // Apply CD-Audio volume to device mixer (CDDA mixing is handled purely on soundcard,
+        // so plug in your 4-pin audio cable from the CD-ROM drive to the soundcard CD-IN)
+        AU_setmixer_one(&aui, AU_MIXCHAN_CDIN, MIXER_SETMODE_ABSOLUTE, cdvol);
+        last_cdvol = cdvol;
     }
 
     aui.card_outbytes = aui.card_dmasize;

--- a/mpxplay/au_cards/sc_e1371.c
+++ b/mpxplay/au_cards/sc_e1371.c
@@ -392,6 +392,7 @@ static void snd_es1371_ac97_init(struct ensoniq_card_s *card)
  snd_es1371_codec_write(card, AC97_MASTER_VOL_STEREO, 0x0404);
  snd_es1371_codec_write(card, AC97_PCMOUT_VOL,        0x0404);
  snd_es1371_codec_write(card, AC97_HEADPHONE_VOL,     0x0404);
+ snd_es1371_codec_write(card, AC97_CD_VOL,            0x0404);
  snd_es1371_codec_write(card, AC97_EXTENDED_STATUS,AC97_EA_SPDIF);
  mpxplay_debugf(ENS_DEBUG_OUTPUT,"ac97 init end");
 }

--- a/mpxplay/au_cards/sc_ich.c
+++ b/mpxplay/au_cards/sc_ich.c
@@ -265,6 +265,7 @@ static void snd_intel_ac97_init(struct intel_card_s *card,unsigned int freq_set)
  snd_intel_codec_write(card, AC97_MASTER_VOL_STEREO, 0x0202);
  snd_intel_codec_write(card, AC97_PCMOUT_VOL,        0x0202);
  snd_intel_codec_write(card, AC97_HEADPHONE_VOL,     0x0202);
+ snd_intel_codec_write(card, AC97_CD_VOL,            0x0202);
  snd_intel_codec_write(card, AC97_EXTENDED_STATUS,AC97_EA_SPDIF);
 
  // set/check variable bit rate bit

--- a/mpxplay/au_cards/sc_sbl24.c
+++ b/mpxplay/au_cards/sc_sbl24.c
@@ -58,6 +58,7 @@ static void snd_emu_ac97_init(struct emu10k1_card *card)
  snd_emu_ac97_write(card, AC97_MASTER_VOL_STEREO, 0x0202);
  snd_emu_ac97_write(card, AC97_PCMOUT_VOL,        0x0202);
  snd_emu_ac97_write(card, AC97_HEADPHONE_VOL,     0x0202);
+ snd_emu_ac97_write(card, AC97_CD_VOL,            0x0202);
  snd_emu_ac97_write(card, AC97_EXTENDED_STATUS,AC97_EA_SPDIF);
 }
 

--- a/mpxplay/au_cards/sc_sbliv.c
+++ b/mpxplay/au_cards/sc_sbliv.c
@@ -424,6 +424,7 @@ static void snd_emu_ac97_init(struct emu10k1_card *card)
  snd_emu_ac97_write(card, AC97_SURROUND_MASTER,   0x0202);
  snd_emu_ac97_write(card, AC97_PCMOUT_VOL,        0x0202);
  snd_emu_ac97_write(card, AC97_HEADPHONE_VOL,     0x0202);
+ snd_emu_ac97_write(card, AC97_CD_VOL,            0x0202);
 
  /*snd_emu_ac97_unmute(card, AC97_MASTER_VOL_STEREO);
  snd_emu_ac97_unmute(card, AC97_SURROUND_MASTER);

--- a/mpxplay/au_cards/sc_via82.c
+++ b/mpxplay/au_cards/sc_via82.c
@@ -204,6 +204,7 @@ static void via82xx_chip_init(struct via82xx_card *card)
  via82xx_ac97_write(card->iobase, AC97_MASTER_VOL_STEREO, 0x0202);
  via82xx_ac97_write(card->iobase, AC97_PCMOUT_VOL,        0x0202);
  via82xx_ac97_write(card->iobase, AC97_HEADPHONE_VOL,     0x0202);
+ via82xx_ac97_write(card->iobase, AC97_CD_VOL,            0x0202);
  via82xx_ac97_write(card->iobase, AC97_EXTENDED_STATUS,AC97_EA_SPDIF);
 }
 

--- a/sbemu/sbemu.h
+++ b/sbemu/sbemu.h
@@ -21,21 +21,31 @@
 
 //register index trhough mixer port
 #define SBEMU_MIXERREG_RESET        0x00
-#define SBEMU_MIXERREG_MASTERVOL    0x02    //SB2.0
-#define SBEMU_MIXERREG_VOICESTEREO  0x04    //SBPro.
-#define SBEMU_MIXERREG_MIDIVOL      0x06    //SB2.0
-#define SBEMU_MIXERREG_VOICEVOL     0x0A    //SB2.0
-#define SBEMU_MIXERREG_MASTERSTEREO 0x22    //SBPro
-#define SBEMU_MIXERREG_MIDISTEREO   0x26    //SBPro 
-//SB16
+
+// CT1335 mixer (SB 2.0)
+#define SBEMU_MIXERREG_MASTERVOL    0x02
+#define SBEMU_MIXERREG_MIDIVOL      0x06
+#define SBEMU_MIXERREG_CDVOL        0x08
+#define SBEMU_MIXERREG_VOICEVOL     0x0A
+
+// CT1345 mixer (SB Pro)
+#define SBEMU_MIXERREG_VOICESTEREO  0x04
+#define SBEMU_MIXERREG_MODEFILTER   0x0E
+#define SBEMU_MIXERREG_MASTERSTEREO 0x22
+#define SBEMU_MIXERREG_MIDISTEREO   0x26
+#define SBEMU_MIXERREG_CDSTEREO     0x28
+
+// CT1745 mixer (SB 16)
 #define SBEMU_MIXRREG_MASTERL       0x30
 #define SBEMU_MIXRREG_MASTERR       0x31
 #define SBEMU_MIXRREG_VOICEL        0x32
 #define SBEMU_MIXRREG_VOICER        0x33
 #define SBEMU_MIXRREG_MIDIL         0x34
 #define SBEMU_MIXRREG_MIDIR         0x35
-//-SB16
-#define SBEMU_MIXERREG_MODEFILTER   0x0E
+#define SBEMU_MIXRREG_CDL           0x36
+#define SBEMU_MIXRREG_CDR           0x37
+
+// Special mixer registers (dynamic reconfiguration of INT/DMA)
 #define SBEMU_MIXERREG_INT_SETUP    0x80
 #define SBEMU_MIXERREG_DMA_SETUP    0x81
 #define SBEMU_MIXERREG_INT_STS      0x82


### PR DESCRIPTION
CD-Audio volume is unmuted on startup, so that the mixer logic
works. Any SB mixer utility can be used to adjust the CD audio
volume.

Supported cards: E1371, ICH/AC97, SB Live!, Audigy, VIA VT82xx.

Tested on: ICH/AC97 (SIS7012).