### PR TITLE
ICH: Add audio routing workaround for AD1980

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For now, this fork provides additional support:
   * CMI 8338 / 8738 (untested)
 * CD-Audio (via 4-pin audio header) unmute/mixer support
 * Toggleable debug output on serial port (/DBG0, /DBG1, /DBG2)
+* Fix audio routing on AC97 (ICH5) with AD1980 (FSC-E600 D1534 with i865G)
 
 ## Supported sound cards
 

--- a/mpxplay/au_cards/sc_ich.c
+++ b/mpxplay/au_cards/sc_ich.c
@@ -34,6 +34,14 @@
 #include "pcibios.h"
 #include "ac97_def.h"
 
+// https://www.analog.com/media/en/technical-documentation/data-sheets/AD1980.pdf
+#define AC97_VENDOR_ID1_AD 0x4144 /* 'A' 'D' */
+#define AC97_VENDOR_ID2_AD1980 0x5370 /* 'S' + 0x70 for AD1980 */
+#define AC97_AD_MISC 0x76    /* Misc Control Bits */
+#define AC97_AD_MISC_AC97NC 0x4000 /* AC'97 No Compatibility Mode (aka ADI compatibility mode) */
+#define AC97_AD_MISC_HPSEL 0x0400 /* Headphone Amplifier Input Select */
+#define AC97_AD_MISC_LOSEL 0x0020 /* LINE_OUT Amplifiers Input Select */
+
 #define ICH_PO_CR_REG     0x1b  // PCM out Control Register
 #define ICH_PO_CR_START   0x01  // start codec
 #define ICH_PO_CR_RESET   0x02  // reset codec
@@ -321,6 +329,18 @@ static void snd_intel_prepare_playback(struct intel_card_s *card,struct mpxplay_
  cmd|=spdif_rate;
  snd_intel_codec_write(card,AC97_SPDIF_CONTROL,cmd);
  pds_delay_10us(10);
+
+ uint16_t vendor_id1 = snd_intel_codec_read(card, AC97_VENDOR_ID1);
+ uint16_t vendor_id2 = snd_intel_codec_read(card, AC97_VENDOR_ID2);
+
+ // Analog Devices AD1980: Fix audio routing (set AC97NC, HPSEL and LOSEL bits)
+ // Thanks to dr.zeissler on the Vogons forum for providing register dumps + testing
+ // https://www.analog.com/media/en/technical-documentation/data-sheets/AD1980.pdf
+ // https://cgit.freebsd.org/src/tree/sys/dev/sound/pcm/ac97_patch.c#n49
+ // https://github.com/torvalds/linux/blob/master/sound/soc/codecs/ad1980.c#L133
+ if (vendor_id1 == AC97_VENDOR_ID1_AD && vendor_id2 == AC97_VENDOR_ID2_AD1980) {
+     snd_intel_codec_write(card, AC97_AD_MISC, AC97_AD_MISC_AC97NC | AC97_AD_MISC_HPSEL | AC97_AD_MISC_LOSEL);
+ }
 
  //set analog ac97 freq
  mpxplay_debugf(ICH_DEBUG_OUTPUT,"AC97 front dac freq:%d ",aui->freq_card);


### PR DESCRIPTION
Three bits need to be set in the special register for audio routing to be fixed.

More information on the Vogons thread: https://www.vogons.org/viewtopic.php?p=1200649#p1200649

Equivalent pull request for upstream SBEMU: https://github.com/crazii/SBEMU/pull/35