### PR TITLE
SB emulation and UI improvements

### DIFF
--- a/main.c
+++ b/main.c
@@ -523,6 +523,8 @@ int main(int argc, char* argv[])
     if (!enablePM && !enableRM) {
         textcolor(RED);
         cprintf("Both real mode & protected mode support are disabled, exiting.\r\n");
+        // play nice with command line
+        textcolor(LIGHTGRAY);
         return 1;
     }
 

--- a/main.c
+++ b/main.c
@@ -242,6 +242,7 @@ struct MAIN_OPT
     "/VOL", "Set master volume (0-9)", 7, 0,
 
     "/K", "Internal sample rate (22050 or 44100)", 0x22050, 0,
+    "/FIXTC", "Fix time constant to match 11/22/44 kHz sample rate", FALSE, 0,
     "/SCL", "List installed sound cards", 0, MAIN_SETCMD_HIDDEN,
     "/SC", "Select sound card index in list (/SCL)", 0, MAIN_SETCMD_HIDDEN,
     "/R", "Reset sound card driver", 0, MAIN_SETCMD_HIDDEN,
@@ -264,6 +265,7 @@ enum EOption
     OPT_OUTPUT,
     OPT_VOL,
     OPT_RATE,
+    OPT_FIX_TC,
     OPT_SCLIST,
     OPT_SC,
     OPT_RESET,
@@ -381,7 +383,7 @@ int main(int argc, char* argv[])
 
         int i = 0;
         while(MAIN_Options[i].option) {
-            printf(" %-6s: %s", MAIN_Options[i].option, MAIN_Options[i].desc);
+            printf(" %-7s: %s", MAIN_Options[i].option, MAIN_Options[i].desc);
             if (i != 0) {
                 printf(", default: %x.\n", MAIN_Options[i].value);
             } else {
@@ -587,7 +589,13 @@ int main(int argc, char* argv[])
     MAIN_SbemuExtFun.DMA_Size = &VDMA_GetCounter;
     MAIN_SbemuExtFun.DMA_Write = &VDMA_WriteData;
 
-    SBEMU_Init(MAIN_Options[OPT_IRQ].value, MAIN_Options[OPT_DMA].value, MAIN_Options[OPT_HDMA].value, MAIN_SB_DSPVersion[MAIN_Options[OPT_TYPE].value], &MAIN_SbemuExtFun);
+    SBEMU_Init(
+        MAIN_Options[OPT_IRQ].value,
+        MAIN_Options[OPT_DMA].value,
+        MAIN_Options[OPT_HDMA].value,
+        MAIN_SB_DSPVersion[MAIN_Options[OPT_TYPE].value],
+        MAIN_Options[OPT_FIX_TC].value,
+        &MAIN_SbemuExtFun);
     VDMA_Virtualize(MAIN_Options[OPT_DMA].value, TRUE);
     if(MAIN_Options[OPT_TYPE].value == 6)
         VDMA_Virtualize(MAIN_Options[OPT_HDMA].value, TRUE);
@@ -1163,17 +1171,27 @@ static void MAIN_TSR_Interrupt()
                 VDMA_Virtualize(MAIN_Options[OPT_HDMA].value, FALSE);
                 VDMA_Virtualize(opt[OPT_HDMA].value, TRUE);
             }
-            if(MAIN_Options[OPT_DMA].value != opt[OPT_DMA].value || MAIN_Options[OPT_HDMA].value != opt[OPT_HDMA].value || MAIN_Options[OPT_IRQ].value != opt[OPT_IRQ].value || opt[OPT_TYPE].value != MAIN_Options[OPT_TYPE].value)
+            if( MAIN_Options[OPT_DMA].value != opt[OPT_DMA].value || MAIN_Options[OPT_HDMA].value != opt[OPT_HDMA].value ||
+                MAIN_Options[OPT_IRQ].value != opt[OPT_IRQ].value || opt[OPT_TYPE].value != MAIN_Options[OPT_TYPE].value ||
+                MAIN_Options[OPT_FIX_TC].value != opt[OPT_FIX_TC].value)
             {
                 _LOG("Reinit SBEMU\n");
                 MAIN_Options[OPT_DMA].value = opt[OPT_DMA].value;
                 MAIN_Options[OPT_HDMA].value = opt[OPT_HDMA].value;
                 MAIN_Options[OPT_IRQ].value = opt[OPT_IRQ].value;
                 MAIN_Options[OPT_TYPE].value = opt[OPT_TYPE].value;
-                SBEMU_Init(MAIN_Options[OPT_IRQ].value, MAIN_Options[OPT_DMA].value, MAIN_Options[OPT_HDMA].value, MAIN_SB_DSPVersion[MAIN_Options[OPT_TYPE].value], &MAIN_SbemuExtFun);
+                MAIN_Options[OPT_FIX_TC].value = opt[OPT_FIX_TC].value;
+                SBEMU_Init(
+                    MAIN_Options[OPT_IRQ].value,
+                    MAIN_Options[OPT_DMA].value,
+                    MAIN_Options[OPT_HDMA].value,
+                    MAIN_SB_DSPVersion[MAIN_Options[OPT_TYPE].value],
+                    MAIN_Options[OPT_FIX_TC].value,
+                    &MAIN_SbemuExtFun);
             }
 
-            if(MAIN_Options[OPT_OPL].value == opt[OPT_OPL].value && MAIN_Options[OPT_ADDR].value == opt[OPT_ADDR].value && MAIN_Options[OPT_PM].value == opt[OPT_PM].value && MAIN_Options[OPT_RM].value == opt[OPT_RM].value)
+            if(MAIN_Options[OPT_OPL].value == opt[OPT_OPL].value && MAIN_Options[OPT_ADDR].value == opt[OPT_ADDR].value &&
+               MAIN_Options[OPT_PM].value == opt[OPT_PM].value && MAIN_Options[OPT_RM].value == opt[OPT_RM].value && MAIN_Options[OPT_FIX_TC].value == opt[OPT_FIX_TC].value)
             {
                 free(opt);
                 return;

--- a/main.c
+++ b/main.c
@@ -953,7 +953,7 @@ static void MAIN_Interrupt()
         _LOG("direct out:%d %d\n",samples,aui.card_samples_per_int);
         memcpy(MAIN_PCM, SBEMU_GetDirectPCM8(), samples);
         SBEMU_ResetDirect();
-        #if 1 //fix noise for some games
+#if 0   //fix noise for some games - SBEMU-X NOTE: unlikely to be needed
         int zeros = TRUE;
         for(int i = 0; i < samples && zeros; ++i)
         {
@@ -965,12 +965,12 @@ static void MAIN_Interrupt()
             for(int i = 0; i < samples; ++i)
                 ((uint8_t*)MAIN_PCM)[i] = 128;
         }
-        #endif
+#endif
         //for(int i = 0; i < samples; ++i) _LOG("%d ",((uint8_t*)MAIN_PCM)[i]); _LOG("\n");
         cv_bits_n_to_m(MAIN_PCM, samples, 1, 2);
         //for(int i = 0; i < samples; ++i) _LOG("%d ",MAIN_PCM[i]); _LOG("\n");
-        const int interrupt_frequency = aui.freq_card/aui.card_samples_per_int;
-        samples = mixer_speed_lq(MAIN_PCM, samples, 1, (samples-1)*interrupt_frequency, aui.freq_card);
+        // the actual sample rate is derived from current count of samples in direct output buffer
+        samples = mixer_speed_lq(MAIN_PCM, samples, 1, (samples * aui.freq_card) / aui.card_samples_per_int, aui.freq_card);
         //for(int i = 0; i < samples; ++i) _LOG("%d ",MAIN_PCM[i]); _LOG("\n");
         cv_channels_1_to_n(MAIN_PCM, samples, 2, 2);
         digital = TRUE;

--- a/sbemu/sbemu.c
+++ b/sbemu/sbemu.c
@@ -687,9 +687,12 @@ int SBEMU_GetDirectCount()
 
 void SBEMU_ResetDirect()
 {
-    SBEMU_DirectBuffer[0] = SBEMU_DirectCount > 1 ? SBEMU_DirectBuffer[SBEMU_DirectCount-1] : 0; //leave one sample for next interpolation
-    SBEMU_DirectCount = 1;
-    //SBEMU_DirectCount = 0;
+#if 1
+    SBEMU_DirectCount = 0;
+#else
+    //SBEMU_DirectBuffer[0] = SBEMU_DirectCount > 1 ? SBEMU_DirectBuffer[SBEMU_DirectCount-1] : 0; //leave one sample for next interpolation
+    //SBEMU_DirectCount = 1;
+#endif
 }
 
 const uint8_t* SBEMU_GetDirectPCM8()

--- a/sbemu/sbemu.c
+++ b/sbemu/sbemu.c
@@ -43,6 +43,7 @@ static int SBEMU_Pos = 0;
 static int SBEMU_DetectionCounter = 0;
 static int SBEMU_DirectCount = 0;
 static int SBEMU_UseTimeConst = 0;
+static int SBEMU_FixTC = 0;
 static uint8_t SBEMU_IRQMap[4] = {2,5,7,10};
 static uint8_t SBEMU_MixerRegIndex = 0;
 static uint8_t SBEMU_idbyte;
@@ -301,7 +302,7 @@ void SBEMU_DSP_Write(uint16_t port, uint8_t value)
             case SBEMU_CMD_SET_TIMECONST:
             {
                 SBEMU_SampleRate = 0;
-                for(int i = 0; i < 3; ++i)
+                if (SBEMU_FixTC != 0) for(int i = 0; i < 3; ++i)
                 {
                     if(value >= SBEMU_TimeConstantMapMono[i][0]-3 && value <= SBEMU_TimeConstantMapMono[i][0]+3)
                     {
@@ -529,13 +530,14 @@ uint8_t SBEMU_DSP_INT16ACK(uint16_t port)
     return 0xFF;
 }
 
-void SBEMU_Init(int irq, int dma, int hdma, int DSPVer, SBEMU_EXTFUNS* extfuns)
+void SBEMU_Init(int irq, int dma, int hdma, int DSPVer, int FixTC, SBEMU_EXTFUNS* extfuns)
 {
     SBEMU_IRQ = irq;
     SBEMU_DMA = dma;
     SBEMU_HDMA = hdma;
     SBEMU_DSPVER = DSPVer;
     SBEMU_ExtFuns = extfuns;
+    SBEMU_FixTC = FixTC;
 
     SBEMU_Mixer_WriteAddr(0, SBEMU_MIXERREG_RESET);
     SBEMU_Mixer_Write(0, 1);

--- a/sbemu/sbemu.h
+++ b/sbemu/sbemu.h
@@ -135,7 +135,7 @@ uint8_t SBEMU_DSP_ReadStatus(uint16_t port); //read buffer status.
 uint8_t SBEMU_DSP_INT16ACK(uint16_t port);
 
 //used by emulations
-void SBEMU_Init(int irq, int dma, int hdma, int DSPVer, SBEMU_EXTFUNS* extfuns); //extfuns must be persistent
+void SBEMU_Init(int irq, int dma, int hdma, int DSPVer, int FixTC, SBEMU_EXTFUNS* extfuns); //extfuns must be persistent
 uint8_t SBEMU_GetIRQ();
 uint8_t SBEMU_GetDMA();
 uint8_t SBEMU_GetHDMA();


### PR DESCRIPTION
Hello, as original SBEMU repo is not updated from April, I'm posting a number of small patches here.

List of changes:
- SB Direct Mode improvements - clear direct audio buffer after use, fix possible precision loss in direct mode sample rate calculation.
 Original code in `SBEMU_ResetDirect()` moves last sample to the start of the buffer, assuming that resampling routine (`mixer_speed_lq()`) needs it for proper resampling. However, `mixer_speed_lq()` already handles buffer start/end cases during interpolation, and this "additional" sample causes crackling artifacts.
 Additionally, "fix noise in some games" (making all-zeroes direct buffer all-128) was temporarily disabled, as it may have false positives at low direct sample rates.
- Time Constant fixup for 11/22/44 kHz moved under the `/FIXTC` option, and disabled by default (see https://www.vogons.org/viewtopic.php?p=1210068#p1210068)
- UI fix: if neither HDPMI nor QEMM/JEMM found and SBEMU aborts, it prints the error message with red color, but forgets to change it back, resulting in further DOS console messages using red color until mode set or attribute change.
  
Hope this will make SBEMU a bit more useful :) Thaks in advance!